### PR TITLE
👷 ci(deploy): pnpm install 명령어의 lockfiles 옵션 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
             ${{ runner.os }}-pnpm- # 캐시 키 복원
 
       - name: Install Dependencies # 의존성 설치
-        run: pnpm install --frozen-lockfiles --prod # 프로덕션 의존성만 설치
+        run: pnpm install --frozen-lockfile --prod # 프로덕션 의존성만 설치
         env:
           CI: ${{ secrets.CI }} # CI 환경 변수 설정
 


### PR DESCRIPTION
- --frozen-lockfiles에서 --frozen-lockfile로 변경하여 의존성 설치 명령어 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 배포 자동화 설정에서 의존성 설치 명령어 플래그를 수정하여, 안정적인 프로덕션 의존성 관리를 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->