### PR TITLE
👷 ci(deploy): husky prepare 스크립트 건너뛰기 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,10 +37,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm- # 캐시 키 복원
 
-      - name: Install Dependencies # 의존성 설치
-        run: pnpm install --frozen-lockfile --prod # 프로덕션 의존성만 설치
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --prod --ignore-scripts # husky prepare 스크립트 건너뛰기
         env:
-          CI: ${{ secrets.CI }} # CI 환경 변수 설정
+          CI: ${{ secrets.CI }}
 
       - name: Generate Prisma Client # Prisma 클라이언트 생성
         run: pnpm prisma generate # pnpm을 사용하여 Prisma 클라이언트 생성


### PR DESCRIPTION
- pnpm install 명령어에 --ignore-scripts 옵션 추가하여 husky prepare 스크립트를 건너뛰도록 수정
- CI 환경에서 의존성 설치 시 불필요한 스크립트 실행 방지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 배포 과정에서 종속성 설치 방식을 최적화하여 불필요한 스크립트 실행을 방지함으로써 빌드 및 배포의 안정성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->