### PR TITLE
👷 ci(deploy): 빌드에 필요한 devDependencies 설치 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
             ${{ runner.os }}-pnpm- # 캐시 키 복원
 
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile --prod --ignore-scripts # husky prepare 스크립트 건너뛰기
+        run: pnpm install --frozen-lockfile --ignore-scripts # 빌드에 필요한 devDependencies도 설치
         env:
           CI: ${{ secrets.CI }}
 


### PR DESCRIPTION
- pnpm install 명령어에서 --prod 옵션 제거하여 devDependencies도 설치하도록 수정
- husky prepare 스크립트를 건너뛰는 옵션은 유지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 배포 프로세스 내 의존성 설치 방식을 개선하여, 빌드 시 필요한 모든 도구와 라이브러리가 포함되도록 업데이트하였습니다. 이 변화로 인해 보다 안정적인 백엔드 빌드와 배포가 기대됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->