### PR TITLE
👷 ci(deploy): pnpm 설치 옵션에서 --frozen-lockfile 제거

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -191,7 +191,7 @@ jobs:
               pm2 delete all || true && \
               # GPG 파일 복호화
               echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --passphrase-fd 0 --output ecosystem.config.js --decrypt ecosystem.config.js.gpg && \
-              pnpm install --prod --frozen-lockfile --ignore-scripts && \
+              pnpm install --prod --ignore-scripts && \
               pnpm prisma generate && \
               pnpm prisma migrate deploy && \
               pm2 start ecosystem.config.js --env production'


### PR DESCRIPTION
- 배포 스크립트에서 `pnpm install` 명령어의 `--frozen-lockfile` 옵션을 제거하여 설치 과정 간소화
- 배포 안정성에 미치는 영향 검토 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 배포 프로세스의 의존성 설치 방식을 조정하여, 고정된 버전 대신 호환 가능한 최신 버전을 설치할 수 있도록 개선했습니다.
  - 이 변경으로 내부 빌드 및 배포의 효율성이 향상되며, 시스템 업데이트 적용이 더욱 원활하게 진행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->