### PR TITLE
👷 ci(deploy): Prisma 명령어를 npx로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -195,10 +195,9 @@ jobs:
               # GPG 파일 복호화
               echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --passphrase-fd 0 --output ecosystem.config.js --decrypt ecosystem.config.js.gpg && \
               pnpm install --prod --ignore-scripts && \
-              pnpm prisma generate && \
-              pnpm prisma migrate deploy && \
+              npx prisma generate && \
+              npx prisma migrate deploy && \
               pm2 start ecosystem.config.js --env production && \
-              # 애플리케이션 시작 확인
               echo "애플리케이션 시작 로그 확인 중..." && \
               sleep 10 && \
               pm2 logs --lines 20 --nostream && \


### PR DESCRIPTION
- 배포 스크립트에서 Prisma 관련 명령어를 pnpm에서 npx로 변경하여 일관성 및 호환성 향상
- GPG 파일 복호화 후 Prisma 명령어 실행 순서 유지