### PR TITLE
👷 ci(deploy): 배포 스크립트에서 PM2 명령어 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -194,7 +194,7 @@ jobs:
               pnpm install --prod --ignore-scripts && \
               pnpm prisma generate && \
               pnpm prisma migrate deploy && \
-              pm2 start ecosystem.config.js --env production
+              pm2 start ecosystem.config.js --env production'
           } 2>&1 | while IFS= read -r line; do
             echo "::add-mask::$line"
             echo "$line"


### PR DESCRIPTION
- `pm2 start` 명령어의 끝에 불필요한 따옴표 제거로 오류 수정
- 배포 스크립트의 가독성 및 안정성 향상