### PR TITLE
👷 ci(deploy): 배포 스크립트에서 PM2 명령어 수정 및 로그 출력 방식 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -190,16 +190,13 @@ jobs:
             scp -i ~/.ssh/id_${{ secrets.EC2_KEY_PAIR_TYPE }} ecosystem.config.js ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }}:~/backend/
             ssh -i ~/.ssh/id_${{ secrets.EC2_KEY_PAIR_TYPE }} ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} 'cd ~/backend && \
               source ~/.nvm/nvm.sh && nvm use 22 && corepack enable && \
-              pm2 stop snack25-be && pm2 delete snack25-be && \
+              pm2 stop snack25-be || true && pm2 delete snack25-be || true && \
               pnpm install --prod --ignore-scripts && \
               pnpm prisma generate && \
               pnpm prisma migrate deploy && \
               pm2 start ecosystem.config.js --env production'
-          } 2>&1 | while IFS= read -r line; do
-            echo "::add-mask::$line"
-            echo "$line"
-            echo "Deploy to EC2 작업 완료"
-          done
+          } 2>&1 | tee deploy.log
+          echo "Deploy to EC2 작업 완료"
 
       - name: Rollback on Failure # 배포 실패 시 롤백
         if: failure()


### PR DESCRIPTION
- `pm2 stop` 및 `pm2 delete` 명령어에 `|| true` 추가로 오류 발생 시에도 스크립트가 중단되지 않도록 수정
- 배포 로그를 `tee` 명령어로 출력하여 로그 파일에 기록하고 콘솔에도 출력하도록 변경
- 배포 완료 메시지를 로그 출력 후에 추가하여 가독성 향상