### PR TITLE
👷 ci(deploy): PM2 명령어를 ID 대신 인스턴스 번호로 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -189,7 +189,7 @@ jobs:
             scp -i ~/.ssh/id_${{ secrets.EC2_KEY_PAIR_TYPE }} ecosystem.config.js ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }}:~/backend/
             ssh -i ~/.ssh/id_${{ secrets.EC2_KEY_PAIR_TYPE }} ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} 'cd ~/backend && \
               source ~/.nvm/nvm.sh && nvm use 22 && corepack enable && \
-              pm2 stop snack25-be && pm2 delete snack25-be && \
+              pm2 stop 0 && pm2 delete 0 && \
               pnpm install --prod --ignore-scripts && \
               pnpm prisma generate && \
               pnpm prisma migrate deploy && \
@@ -203,7 +203,7 @@ jobs:
           ssh ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} 'cd ~/backend && {
             if ls backup-*.tar.gz 1> /dev/null 2>&1; then
               echo "Backup found, restoring..."
-              pm2 delete snack25-be || true
+              pm2 delete 0 || true
               tar -xzf backup-*.tar.gz
               pm2 start ecosystem.config.js --env production
               echo "Rollback complete."


### PR DESCRIPTION
- 배포 스크립트에서 PM2 명령어를 인스턴스 ID 대신 인스턴스 번호(0)로 변경하여 일관성 및 안정성 향상
- 백업 복원 시 PM2 삭제 명령어도 동일하게 수정