### PR TITLE
🔧 chore(dependencies): dotenv-cli 추가 및 @babel/helpers 버전 업데이트

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "class-validator": "^0.14.1",
     "cookie-parser": "^1.4.7",
     "cross-env": "7.0.3",
+    "dotenv-cli": "8.0.0",
     "multer": "1.4.5-lts.1",
     "multer-s3": "^3.0.1",
     "passport": "^0.7.0",
@@ -89,7 +90,6 @@
     "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6.0.2",
     "commitlint-config-gitmoji": "2.3.1",
-    "dotenv-cli": "8.0.0",
     "eslint": "^9.22.0",
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-prettier": "^5.2.2",
@@ -134,6 +134,9 @@
       "argon2",
       "esbuild",
       "prisma"
-    ]
+    ],
+    "overrides": {
+      "@babel/helpers@<7.26.10": ">=7.26.10"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
+overrides:
+  '@babel/helpers@<7.26.10': '>=7.26.10'
+
 importers:
 
   .:
@@ -56,6 +59,9 @@ importers:
       cross-env:
         specifier: 7.0.3
         version: 7.0.3
+      dotenv-cli:
+        specifier: 8.0.0
+        version: 8.0.0
       multer:
         specifier: 1.4.5-lts.1
         version: 1.4.5-lts.1
@@ -129,9 +135,6 @@ importers:
       commitlint-config-gitmoji:
         specifier: 2.3.1
         version: 2.3.1
-      dotenv-cli:
-        specifier: 8.0.0
-        version: 8.0.0
       eslint:
         specifier: ^9.22.0
         version: 9.22.0(jiti@2.4.2)
@@ -421,8 +424,8 @@ packages:
     resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.26.9':
-    resolution: {integrity: sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==}
+  '@babel/helpers@7.26.10':
+    resolution: {integrity: sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.26.9':
@@ -527,6 +530,10 @@ packages:
 
   '@babel/traverse@7.26.9':
     resolution: {integrity: sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.26.10':
+    resolution: {integrity: sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.26.9':
@@ -5149,7 +5156,7 @@ snapshots:
       '@babel/generator': 7.26.9
       '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.9)
-      '@babel/helpers': 7.26.9
+      '@babel/helpers': 7.26.10
       '@babel/parser': 7.26.9
       '@babel/template': 7.26.9
       '@babel/traverse': 7.26.9
@@ -5202,10 +5209,10 @@ snapshots:
 
   '@babel/helper-validator-option@7.25.9': {}
 
-  '@babel/helpers@7.26.9':
+  '@babel/helpers@7.26.10':
     dependencies:
       '@babel/template': 7.26.9
-      '@babel/types': 7.26.9
+      '@babel/types': 7.26.10
 
   '@babel/parser@7.26.9':
     dependencies:
@@ -5313,6 +5320,11 @@ snapshots:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/types@7.26.10':
+    dependencies:
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
 
   '@babel/types@7.26.9':
     dependencies:


### PR DESCRIPTION
- dotenv-cli 패키지를 추가하여 환경 변수 관리를 개선
- @babel/helpers의 버전을 7.26.10으로 업데이트하여 호환성 향상
- pnpm-lock.yaml 파일에서 관련 의존성 정보 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

이번 업데이트는 애플리케이션의 안정성과 호환성을 강화하기 위한 내부 의존성 관리 개선에 중점을 두었습니다. 이 변경 사항은 사용자 경험에 간접적으로 긍정적인 영향을 미쳐, 보다 신뢰할 수 있는 서비스 제공에 기여합니다.

- **Chores**
  - 필수 의존성이 프로덕션 환경에 맞게 재구성되었습니다.
  - 특정 패키지의 버전 호환성을 보장하기 위한 관리 규칙이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->