### PR TITLE
🚀 ci(deploy): 의존성 설치 스크립트 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -446,7 +446,7 @@ jobs:
 
           # 의존성 설치
           echo "[INFO] Installing dependencies..."
-          if ! pnpm install --frozen-lockfile --prod --ignore-scripts; then
+          if ! pnpm install --prod --ignore-scripts; then
             echo "❌ 의존성 설치 실패"
             exit 1
           fi


### PR DESCRIPTION
- `pnpm install` 명령어에서 `--frozen-lockfile` 플래그 제거
- 의존성 설치 시 dev 의존성 제외 및 pre/post 스크립트 실행 제외 유지